### PR TITLE
use espower-loader directly to deal with multiple test directory

### DIFF
--- a/enable-power-assert.js
+++ b/enable-power-assert.js
@@ -1,0 +1,6 @@
+require('espower-loader')({
+    // directory where match starts with
+    cwd: process.cwd(),
+    // glob pattern using minimatch module
+    pattern: '**/test/**/*.js'
+});

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha -r intelli-espower-loader",
+    "all-test": "mocha -r enable-power-assert src/test test",
     "fail-load": "mocha src/test/ -r intelli-espower-loader"
   },
   "keywords": [],
@@ -12,6 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "intelli-espower-loader": "^1.0.1",
+    "espower-loader": "^1.0.0",
     "mocha": "^2.4.5",
     "power-assert": "^1.3.1"
   }


### PR DESCRIPTION
To deal with customized or multiple test directories, specify minimatch [pattern](https://github.com/power-assert-js/espower-loader#example) using [espower-loader](https://github.com/power-assert-js/espower-loader) directly.
